### PR TITLE
Update affiliations to reflect new participations

### DIFF
--- a/elections/2023/affiliation-designated-voters.md
+++ b/elections/2023/affiliation-designated-voters.md
@@ -7,7 +7,7 @@ Following [Solid CG Chair Election Procedure](https://github.com/solid/specifica
 To designate a representative please edit the table and add their full name (as it appears in their W3C account or https://www.w3.org/groups/cg/solid/participants/ ) in the *Designated* column.
 In cases where there is no designated representative the one in the *Default* column will be included in the list of elegible voters!
 
-List generated on 2023-11-08 using [solid-ecosystem-monitor](https://github.com/VirginiaBalseiro/solid-ecosystem-monitor/pull/2)
+List generated on 2023-11-11 using [solid-ecosystem-monitor](https://github.com/VirginiaBalseiro/solid-ecosystem-monitor/)
 
 | Name                                                                          | Members | Default                 | Designated |
 | :---------------------------------------------------------------------------- | :------ | :---------------------- | :--------- |
@@ -17,6 +17,7 @@ List generated on 2023-11-08 using [solid-ecosystem-monitor](https://github.com/
 | Defense Information Systems Agency                                            | 2       | Jeff Waters             |            |
 | Digita                                                                        | 2       | Tom Haegemans           |            |
 | Electronics and Telecommunications Research Institute (ETRI)                  | 2       | Kangchan Lee            |            |
+| Forschungszentrum Informatik (FZI)                                            | 2       | Tobias Kaefer           |            |
 | Ghent University                                                              | 3       | Esther De Loof          |            |
 | Graphmetrix, Inc.                                                             | 3       | Frederick Gibson        |            |
 | Inrupt Inc.                                                                   | 14      | Timea Turdean           | Aaron Coburn |

--- a/elections/2023/affiliation-designated-voters.md
+++ b/elections/2023/affiliation-designated-voters.md
@@ -17,7 +17,7 @@ List generated on 2023-11-11 using [solid-ecosystem-monitor](https://github.com/
 | Defense Information Systems Agency                                            | 2       | Jeff Waters             |            |
 | Digita                                                                        | 2       | Tom Haegemans           |            |
 | Electronics and Telecommunications Research Institute (ETRI)                  | 2       | Kangchan Lee            |            |
-| Forschungszentrum Informatik (FZI)                                            | 2       | Tobias Kaefer           |            |
+| Forschungszentrum Informatik (FZI)                                            | 2       | Tobias Kaefer           | Christoph Braun |
 | Ghent University                                                              | 3       | Esther De Loof          |            |
 | Graphmetrix, Inc.                                                             | 3       | Frederick Gibson        |            |
 | Inrupt Inc.                                                                   | 14      | Timea Turdean           | Aaron Coburn |
@@ -36,3 +36,4 @@ List generated on 2023-11-11 using [solid-ecosystem-monitor](https://github.com/
 ## Notes
 
 * Aaron Coburn - self-designated [during Solid CG meeting 2023-11-08](https://github.com/solid/specification/pull/595)
+* Christoph Braun designated by Christoph Braun and Tobias Kaefer: https://github.com/w3c-cg/solid/pull/2#issuecomment-1807146352


### PR DESCRIPTION
There was a new participant, Tobias Kaefer ( @kaefer3000 ) affiliated with Forschungszentrum Informatik (FZI) joining the CG on 2023-11-10. And so FZI has a second participant in addition to Christoph Braun ( @uvdsl ).

The data in this PR is based on re-running the code in https://github.com/VirginiaBalseiro/solid-ecosystem-monitor/tree/main/node-w3capi as of 2023-11-11 and adds FZI to the list where Tobias is by default the representative that's eligible to vote.

Tobias, Christoph, if you prefer the default to change to Christoph, you may say so in this PR comment and we can reflect those changes.

CG chair election volunteers: we'll just do this minor updates to the affiliation if/when there is a change along these lines until 2023-11-14 as agreed.