### PR TITLE
Add a TXT snapshot of Solid CG members

### DIFF
--- a/elections/2025/cg-members-snapshot.txt
+++ b/elections/2025/cg-members-snapshot.txt
@@ -1,0 +1,304 @@
+This snapshot of Solid CG members has been taken with https://github.com/VirginiaBalseiro/solid-ecosystem-monitor on 2025-11-26 14:56 UTC.
+
+Aad Versteden
+Aaron Coburn
+Abel Van den Briel
+Adams Gravitis
+Adam Sobieski
+Akshay Kanthi
+Alain Bourgeois
+Alan Davies
+Albert Esterline
+Alessio Nobile
+Alice Poggioli
+aligo Kang
+Ali Siragedien
+Amber Blue
+Amin Anjomshoaa
+Amod Malviya
+Amy Guy
+Andrea Cimmino
+Andreas Prieß
+Andrea Torino Rodriguez
+Andrei Ciortea
+André Pomp
+Angel Araya
+Angelo Veltens
+Antoine Zimmermann
+April Daly
+Armando Ramos
+Arne Hassel
+Arnold Chen
+Aron Homberg
+Arto Bendiken
+Ashish S Sharma
+A Soroka
+Augusto Mathurin
+Auke van Slooten
+Bart Hanssens
+Bas Buller
+Beatriz Esteves
+Benoit Alessandroni
+Bert Jehoul
+biagio boi
+Billy Wilson Arante
+bin ke
+bob bishop
+Brad Jones
+Brendan Quinn
+Brian Kim
+Bruno Volckaert
+Calum Inverarity
+Carlo Tosoni
+Caroline Gans Combe
+Charity Langley
+Charles Todd
+Charlie Halford
+Chiali Tsai
+Chris Min
+Christian Buggedei
+Christine Perey
+Christoph Braun
+Christophe R Patraldo
+Christopher Prince
+Ciprian Ciubotariu
+damodara _
+Damon Outlaw
+Danica D'hont
+Daniel Bakas
+Daniel Schraudner
+Daniel Vangrieken
+Daniel Zuckerman
+Daphne Muller
+David Dabbs
+David Ezell
+david faveris
+david mason
+David Waite
+davi ottenheimer
+Devaraj Muthuvelmanickam
+diego pacheco
+Dmitri Zagidulin
+Dörthe Arndt
+Dr CKLinn
+Eamonn Costello
+Eduardo Ibacache Rodriguez
+Edwin Steiner
+Ege Korkan
+Ellen Rapaport
+Emmet Townsend
+Erfan Gholami
+Erich Bremer
+Eric Jahn
+Eric Prud'hommeaux
+Eric Woodward
+Esther De Loof
+Eugene Park
+Evan Meyers
+Fabio Barone
+Filippo Nardocci
+Fong An
+francois branciard
+Frank Kroon
+Frederick Gibson
+Fredric Landqvist
+Gabriel Rosset
+Ganesh Kumble
+Garethe Hughes
+Gary Murphy
+Geongyu Bae
+Gerald Melles
+Gordana Halavanja
+Gourab Saha
+Guilherme Siquinelli
+Hadrian Zbarcea
+Hannah Short
+Han Su
+Hari Om Dwivedi
+Harrison Tang
+Harshvardhan J. Pandit
+Hindia Mohammed
+Hong Sun
+Hooman Mohajeri Moghaddam
+huanyu cai
+Hua-Rong Chu
+Hu Liu
+Huw Diprose
+Ila Benjamin
+Ines Akaichi
+Inge La Riviere
+Jackson Morgan
+Jacqui Vo
+James Birmingham
+James Doe
+James Martin
+James Randall
+Jan Schill
+Jeeth Garageshwara
+Jeff Waters
+Jeff Zucker
+Jegan Davies-Jones
+Jeong Yun Moon
+Jesse Wright
+Jess Moore
+Joachim Van Herwegen
+Joaquin Salvachua
+Johan Regnström
+John Bruce
+John Erickson
+John Kirkwood
+Johnny (Qiang) Chen
+John Yu
+Jonas Smedegaard
+Jon Pederson
+Jose Emilio Labra Gayo
+Joshua Cornejo
+Justin Bingham
+Kabul Kurniawan
+Kai Gilb
+Kangchan Lee
+Kayode Ezike
+Keith Lawson
+Kelly O'Brien
+Kerensa Jennings
+Kévin Dunglas
+Kevin Poulsen
+Kevin Weber
+Khaled Mathlouthi
+Khalid Alnuaim
+Kingsley Idehen
+Kjetil Kjernsmo
+Knut-Olav Hoven
+kofi kyei
+Konstantinos Kotis
+Kurt Cagle
+Kushal Das
+Kyra .
+Lauernce Zhang
+Laurens Debackere
+Leonard Rosenthol
+Leon Porter
+Li Ding
+Lily Park
+lin ye
+Lucy Arrowsmith
+Mahdi Baghbani
+Maico Oliveira Buss
+Marco Neumann
+Mark Lizar
+Mark Senefsky
+Mark Thompson
+Mark Wallis
+Mark Weiler
+Matthew Fowle
+Matthias Evering
+Matthieu Bosquet
+Matt Taylor
+Matt Wallis
+Maxime Lecoq
+Max Leonard
+Meem Arafat Manab
+Meindert Osinga
+Melvin Carvalho
+Michaël Dierick
+Michael Herman
+Michael Paduch
+Michael Pigott
+Michael Toomim
+Michal @mrkvon
+Michiel Bellens
+Michiel de Jong
+Miguel Ceriani
+Mike Adams
+Mike Orchard
+Mischa Tuffield
+Nicolaas Pereboom
+Nicolas Seydoux
+Noah Ortiz
+Onur Yüksel
+Oshani Seneviratne
+Owen Sacco
+Pano Maria
+Pasquale Boemio
+Paul Daly
+Paul deGrandis
+Paul Mundt
+Paul Worrall
+Pavlik elf
+Pavlos Pseftoyiannis
+Peter Bruhn Andersen
+Peter Rivett
+Peter Smith
+Philip Laszkowicz
+Philippe Duchesne
+Pierre-Antoine Champin
+Pieter van Everdingen
+Pol Alvarez
+Precious Oritsedere
+Rafael Richards
+Rahul Gupta
+Rami Rustom
+Ram Kripa
+Raúl R. Pearson
+Renoir Boulanger
+Richard Marshall
+Rishabh Gupta
+RJ Herrick
+Robbie Yang
+Roderick Kennedy
+Roger Perry
+Ron Herardian
+Ross Horne
+Roy Leon
+Rui Zhao
+Sabrina Kirrane
+Samu Lang
+Samy Vincent
+Santi Lozano
+Sarven Capadisli
+Sébastien Dubois
+Sébastien Rosset
+Seila Gonzalez Estrecha
+Sharon Stratsianis
+Sheff Engi
+Simon Grant
+Simon Louvet
+Sindhu Raju
+Soheil Roshankish
+soonkuk kang
+Souen Mazouin
+Stephen Taylor
+Steve Olshansky
+Sungjae Jung
+Syed Ali Raza Zaidi
+Sylvain Le Bon
+Sylvain Saint-André
+Taekhoon Kim
+Takeo Nishikata
+Tao Chen
+Ted Thibodeau Jr
+Teodora Petkova
+th hck
+Thierry Marianne
+Thomas Gallagher
+Thomas Schouten
+thosleaf thos
+Tim Standen
+Tobias Kaefer
+Tolga Coplu
+Tommaso Crepax
+Tommy Lindberg
+Torbjörn Lager
+Travis Vachon
+Víctor Rodríguez-Doncel
+Virginia Balseiro
+Wim Tobback
+Wonsuk Lee
+Wouter Kok
+Wouter Termont
+Yatharth (Arjun) Mishra
+Yehua Chen
+Yen-Lin Huang
+Yuhang Shi
+Yvo Brevoort
+Zixuan Chen


### PR DESCRIPTION
Snapshot taken with https://github.com/VirginiaBalseiro/solid-ecosystem-monitor 2025-11-26 14:56 UTC
Prerequisite to #38 
Fixes #36