### PR TITLE
Propose designated voter for Ponder Source because default voter left CG

### DIFF
--- a/elections/2025/affiliation-designated-voters.md
+++ b/elections/2025/affiliation-designated-voters.md
@@ -26,7 +26,7 @@ List generated on 2025-11-20 using [solid-ecosystem-monitor](https://github.com/
 | Muze                                                                          | 2       | Yvo Brevoort            |            |
 | Open Data Institute                                                           | 4       | Samu Lang               |            |
 | OpenLink Software Inc.                                                        | 2       | Kingsley Idehen         |            |
-| Ponder Source                                                                 | 2       | Michiel de Jong         |            |
+| Ponder Source                                                                 | 2       | Michiel de Jong         | Mahdi Baghbani  |
 | REDPENCIL                                                                     | 2       | Aad Versteden           |            |
 | Rensselaer Polytechnic Institute                                              | 2       | John Erickson           |            |
 | Sakak                                                                         | 2       | Geongyu Bae             |            |


### PR DESCRIPTION
The default voter for Ponder Source has left the CG after the snapshot of CG participants has been made. Proposed designated voter is the only remaining CG participant affiliated with Ponder Source.
See also https://api.w3.org/participations/39819/participants

This proposal should be approved by someone from Ponder Source. Without approval, it must be disregarded if Michiel de Jong rejoins the CG before election.

@michielbdejong @MahdiBaghbani